### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "pthreadpool"
+description := "A portable and efficient thread pool implementation."
+gitrepo     := "https://github.com/Maratyszcza/pthreadpool.git"
+homepage    := "https://github.com/Maratyszcza/pthreadpool/"
+license     := "BSD-2-Clause"
+version     := 7604215 sha256:91c7b00c16c60c96f23d1966d524879c0f6044caf4bc5e9fc06518dda643e07e https://github.com/Maratyszcza/pthreadpool/archive/7604215.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

